### PR TITLE
TOOLS-5450: Pull docker-compose values from env vars

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
       context: ./resultsmanager
     environment:
       #Change to fhir data provider within the internal EHR
-      CQL_EXECUTION_DATA_SERVICE: "https://apps.hdap.gatech.edu/gt-fhir/fhir/"
+      CQL_EXECUTION_DATA_SERVICE: "${CQL_EXECUTION_DATA_SERVICE:-https://apps.hdap.gatech.edu/gt-fhir/fhir/}"
       #Basic authentication credentials to the data service
       CQL_EXECUTION_DATA_USER: ""
       CQL_EXECUTION_DATA_PASS: ""


### PR DESCRIPTION
**Ticket:**
https://jira.ochin.org/browse/TOOLS-5450

**Problem:**
There are hardcoded values in `docker-compose` that we need to override to point at OCHIN resources (Epic)

**Solution:**
There is a [docker syntax for referencing env vars](https://docs.docker.com/compose/compose-file/#variable-substitution)

**Notes:**
1. Because we have a working relationship with the devs that maintain the upstream repo, I will probably put in a PR from our master when this merges. It may be helpful to them as they try to get other places to adopt there tech
2. There is a PostgreSQL server in a container in this docker file. I would eventually like to move it into an RDS instance which I think we could do using this technique. However, when I spoke with the GT devs, they mentioned some other code alterations would be necessary to make it work so I'm hesitant to dive into that now. We should eventually though because if we run `docker-compose down` we will lose our data and have no backup